### PR TITLE
i#1551,i#1569,i#3544: Port sample 'cbr' to AARCHXX and RISCV64.

### DIFF
--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -241,8 +241,8 @@ add_sample_client(memtrace_simple "memtrace_simple.c;utils.c" "drmgr;drreg;druti
 add_sample_client(memval_simple   "memval_simple.c;utils.c"   "drmgr;drreg;drutil;drx")
 add_sample_client(instrace_simple "instrace_simple.c;utils.c" "drmgr;drreg;drx")
 add_sample_client(opcode_count    "opcode_count.cpp"    "drmgr;drreg;drx;droption")
+add_sample_client(cbr         "cbr.c"           "drmgr;drreg")
 if (X86) # FIXME i#1551, i#1569, i#3544: port to ARM/AArch64/RISCV64
-  add_sample_client(cbr         "cbr.c"           "drmgr")
   add_sample_client(countcalls  "countcalls.c"    "drmgr;drreg")
   add_sample_client(inc2add     "inc2add.c"       "drmgr;drreg")
   add_sample_client(memtrace_x86_binary "memtrace_x86.c;utils.c"

--- a/core/ir/riscv64/instr.c
+++ b/core/ir/riscv64/instr.c
@@ -238,10 +238,8 @@ instr_is_near_ubr(instr_t *instr)
 bool
 instr_is_cti_short(instr_t *instr)
 {
-    /* The branch with smallest reach is direct branch, with range +/- 4 KiB.
-     * We have restricted MAX_FRAGMENT_SIZE on RISCV64 accordingly.
-     */
-    return false;
+    int opc = instr_get_opcode(instr);
+    return (opc == OP_c_beqz || opc == OP_c_bnez);
 }
 
 bool

--- a/core/ir/riscv64/ir_utils.c
+++ b/core/ir/riscv64/ir_utils.c
@@ -50,9 +50,13 @@ remangle_short_rewrite(dcontext_t *dcontext, instr_t *instr, byte *pc, app_pc ta
 instr_t *
 convert_to_near_rel_arch(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
-    return NULL;
+    int opc = instr_get_opcode(instr);
+    if (opc == OP_c_beqz)
+        instr_set_opcode(instr, OP_beq);
+    else if (opc == OP_c_bnez)
+        instr_set_opcode(instr, OP_bne);
+
+    return instr;
 }
 
 static int


### PR DESCRIPTION
Modified 1: For RISCV64, conditional branch instruction of  'C' extension may not reach after adding clean call. So like X86, we add support for detect and convert compressed cbr to longer version.
Modified 2: For AARCHXX and RISCV64, a cbr may use the stolen reg and can not be mangled later as it is meta. So we check whether a cbr uses the stolen reg and replace it with a scratch reg.

After thess two modifications, cbr works for AARCHXX and RISCV64.

i#1551,i#1569,i#3544