### PR TITLE
Fix insert_save_type_and_size for drmemtrace

### DIFF
--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -332,6 +332,23 @@ online_instru_t::insert_save_type_and_size(void *drcontext, instrlist_t *ilist,
         MINSERT(ilist, where,
                 XINST_CREATE_store(drcontext, OPND_CREATE_MEM32(base, disp),
                                    opnd_create_reg(scratch)));
+#elif defined(RISCV64)
+        scratch = reg_resize_to_opsz(scratch, OPSZ_4);
+        /* li scratch, #size */
+        MINSERT(ilist, where,
+                XINST_CREATE_load_int(drcontext, opnd_create_reg(scratch),
+                                      OPND_CREATE_INT(size)));
+        /* SLLI scratch, scratch, 16 */
+        MINSERT(ilist, where,
+                INSTR_CREATE_slli(drcontext, opnd_create_reg(scratch),
+                                  opnd_create_reg(scratch), OPND_CREATE_INT8(16)));
+        /* ORI scratch, scratch, #type */
+        MINSERT(ilist, where,
+                INSTR_CREATE_ori(drcontext, opnd_create_reg(scratch),
+                                 opnd_create_reg(scratch), OPND_CREATE_INT(type)));
+        MINSERT(ilist, where,
+                XINST_CREATE_store(drcontext, OPND_CREATE_MEM32(base, disp),
+                                   opnd_create_reg(scratch)));
 #endif
     }
 }

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -684,6 +684,11 @@ insert_conditional_skip(void *drcontext, instrlist_t *ilist, instr_t *where,
     MINSERT(ilist, where,
             INSTR_CREATE_cbz(drcontext, opnd_create_instr(skip_label),
                              opnd_create_reg(reg_skip_if_zero)));
+#elif defined(RISCV64)
+    MINSERT(ilist, where,
+            INSTR_CREATE_beq(drcontext, opnd_create_instr(skip_label),
+                             opnd_create_reg(reg_skip_if_zero),
+                             opnd_create_reg(DR_REG_X0)));
 #endif
 }
 


### PR DESCRIPTION
Fix the issue in insert_save_type_and_size where the absence of code related to the RISC-V 64 architecture causes problems with counting instruction fetches.